### PR TITLE
fix: Fixed lib tsconfig

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -2,6 +2,11 @@
   "compilerOptions": {
     "outDir": "../build",
     "target": "ES5",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "declaration": true,
     "strict": true,
     "esModuleInterop": true


### PR DESCRIPTION
```
node_modules/@types/react/index.d.ts#L1
Cannot find name 'Set'. Do you need to change your target library? Try changing the `lib` compiler option to es2015 or later.
```
